### PR TITLE
Changes in architecture specific code as required by upstream changes.

### DIFF
--- a/arch/mips/cpu/24K/cpu_interrupts.c
+++ b/arch/mips/cpu/24K/cpu_interrupts.c
@@ -99,11 +99,6 @@ void vmm_interrupts_restore(irq_flags_t flags)
 			     :"=r"(temp));
 }
 
-s32 vmm_vcpu_irq_execute (vmm_vcpu_t *vcpu,vmm_user_regs_t *regs,u32 interrupt_no,u32 reason)
-{
-	return VMM_OK;
-}
-
 s32 generic_int_handler(vmm_user_regs_t *uregs)
 {
         u32 cause = read_c0_cause();

--- a/arch/mips/cpu/24K/cpu_timer.c
+++ b/arch/mips/cpu/24K/cpu_timer.c
@@ -42,7 +42,7 @@
 
 unsigned long long jiffies;
 
-void vmm_cpu_timer_setup(void)
+void vmm_cpu_timer_setup(u32 tick_usecs)
 {
         jiffies = 0;
 }

--- a/arch/mips/cpu/24K/cpu_vcpu_irq.c
+++ b/arch/mips/cpu/24K/cpu_vcpu_irq.c
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2011 Himanshu Chauhan
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * @file cpu_vcpu_irq.c
+ * @version 0.1
+ * @author Himanshu Chauhan (hschauhan@nulltrace.org)
+ * @brief source code for handling vcpu interrupts
+ */
+
+#include <vmm_error.h>
+#include <vmm_cpu.h>
+#include <vmm_vcpu_irq.h>
+
+u32 vmm_vcpu_irq_count(vmm_vcpu_t * vcpu)
+{
+	return 7;
+}
+
+u32 vmm_vcpu_irq_priority(vmm_vcpu_t * vcpu, u32 irq_no)
+{
+	/* all at same priority */
+	return 1;
+}
+
+int vmm_vcpu_irq_execute(vmm_vcpu_t * vcpu,
+			 vmm_user_regs_t * regs, 
+			 u32 irq_no, u32 reason)
+{
+	return VMM_OK;
+}

--- a/arch/mips/cpu/24K/include/vmm_cpu.h
+++ b/arch/mips/cpu/24K/include/vmm_cpu.h
@@ -59,9 +59,12 @@ s32 vmm_vcpu_irq_execute(vmm_vcpu_t *vcpu,vmm_user_regs_t *regs,
 irq_flags_t vmm_interrupts_save(void);
 void vmm_interrupts_restore(irq_flags_t flags);
 s32 vmm_vcpu_irq_execute(vmm_vcpu_t *vcpu,vmm_user_regs_t *regs,u32 interrupt_no,u32 reason);
+u32 vmm_vcpu_irq_priority(vmm_vcpu_t * vcpu, u32 irq_no);
+u32 vmm_vcpu_irq_count(vmm_vcpu_t * vcpu);
+
 
 /** Timer related functions required by VMM core */
-void vmm_cpu_timer_setup(void);
+void vmm_cpu_timer_setup(u32 tick_usecs);
 void vmm_cpu_timer_enable(void);
 void vmm_cpu_timer_disable(void);
 

--- a/arch/mips/cpu/24K/objects.mk
+++ b/arch/mips/cpu/24K/objects.mk
@@ -38,3 +38,4 @@ cpu-objs-y+= cpu_timer.o
 cpu-objs-y+= cpu_interrupts.o
 cpu-objs-y+= cpu_host_aspace.o
 cpu-objs-y+= cpu_hyperthreads.o
+cpu-objs-y+= cpu_vcpu_irq.o


### PR DESCRIPTION
- Change in timer setup (uticks is now passed as parameter).
- Removed vcpu irq execute from cpu_interrupts.c and moved it to
  vcpu specific file. Hence addition of cpu_vcpu_irq.c
- Added/Changed function definitions in vmm_cpu.h to reflect above
  changes.

Signed-off-by: Himanshu Chauhan hschauhan@nulltrace.org
