### PR TITLE
Improved stability of GIC emulator

### DIFF
--- a/emulators/pic/gic.c
+++ b/emulators/pic/gic.c
@@ -489,6 +489,10 @@ static int gic_dist_writeb(struct gic_state * s, int cpu, u32 offset, u8 src)
 	if (!done) {
 		done = 1;
 		switch (offset >> 8) {
+		case 0x1: /* Reserved */
+		case 0x2: /* Reserved */
+		case 0x3: /* Reserved */
+			break;
 		case 0x4: /* Priority */
 			irq = offset - 0x400;
 			if (GIC_NUM_IRQ(s) <= irq) {


### PR DESCRIPTION
[EMULATORS] Minor fix in GIC emulator. This improves stablity of ARM test code running in a Realview PB-A8 guest.

Signed-off-by: Anup Patel anup@brainfault.org
