### PR TITLE
[DOCS] Update last commit tag in v0.2.4 release notes

### DIFF
--- a/docs/releases/v0.2.4
+++ b/docs/releases/v0.2.4
@@ -1,5 +1,5 @@
 			Xvisor v0.2.4
-		(Last Commit: ------------)
+	(Last Commit: 4486981078ddf368c7a2a2cc94e47a959028af6f)
 		(Release Date: 23-Feb-2014)
 
 In this release, we add lot of new features, drivers, and emulators.


### PR DESCRIPTION
Post taggig v0.2.4 we update release notes about last commit tag
of v0.2.4 release.

Signed-off-by: Anup Patel anup@brainfault.org
