### PR TITLE
[DOCS] Update last commit tag in v0.2.5 release notes

### DIFF
--- a/docs/releases/v0.2.5
+++ b/docs/releases/v0.2.5
@@ -1,5 +1,5 @@
 			Xvisor v0.2.5
-		(Last Commit: ------------)
+	(Last Commit: 73583c604d598986457314540b43745fa4817437)
 		(Release Date: 09-Oct-2014)
 
 In this release, we have new features, drivers, and emulators.


### PR DESCRIPTION
We have tagged the v0.2.5 release hence update the release
notes with last commit tag info.

Signed-off-by: Anup Patel anup@brainfault.org
