### PR TITLE
Add export for CROSS_COMPILE environment variable

### DIFF
--- a/docs/arm/bcm2835-raspi.txt
+++ b/docs/arm/bcm2835-raspi.txt
@@ -23,7 +23,7 @@ the boot partition of SD card:
 Following are steps to create these images and boot Xvisor on Raspberry Pi:
 
   [1. Build environment]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>
@@ -134,7 +134,7 @@ Please follow the steps below to build & run Basic Firmware on
 Realview-EB-MPCore guest with Xvisor running on QEMU Raspberry-Pi Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/bcm2836-raspi2.txt
+++ b/docs/arm/bcm2836-raspi2.txt
@@ -34,7 +34,7 @@ partition of SD card:
 Following are steps to create these images and boot Xvisor on Raspberry Pi2:
 
   [1. Build environment]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/exynos4-nuri.txt
+++ b/docs/arm/exynos4-nuri.txt
@@ -11,7 +11,7 @@ Please follow the steps below to build & run Basic Firmware on Realview-PB-A8
 guest with Xvisor running on QEMU NURI Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/exynos4-odroidx.txt
+++ b/docs/arm/exynos4-odroidx.txt
@@ -18,7 +18,7 @@ ODroid-X:
 Following steps to create these images and then boot Xvisor on ODroid-X:
 
   [1. Build environment]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/exynos4-smdkc210.txt
+++ b/docs/arm/exynos4-smdkc210.txt
@@ -11,7 +11,7 @@ Please follow the steps below to build & run Basic Firmware on Realview-PB-A8
 guest with Xvisor running on QEMU SMDKC210 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/fast-models.txt
+++ b/docs/arm/fast-models.txt
@@ -76,7 +76,7 @@ steps provided in previous section:
 
   [1. Build environment for boot-wrapper]
   # cd <your_test_dir>
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. Compile boot-wrapper]
   # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mcpu=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOOP_ADDR=0x14000000 -DVEXPRESS_A15 -DIMAGE=fast_model_boot.img <xvisor_source_directory>/docs/arm/fast_model_boot.S -o fast_model_boot.axf

--- a/docs/arm/omap3-beagle.txt
+++ b/docs/arm/omap3-beagle.txt
@@ -15,7 +15,7 @@ Following are the steps to create these images and then boot Xvisor on
 Beagleboard-xM using U-Boot-2011.03 or higher:
 
   [1. Build environment]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>
@@ -135,7 +135,7 @@ The steps to create these images and boot Xvisor on Beagleboard QEMU are as
 follows:
 
   [1. Build environment]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. Download and build U-Boot-2011.03 from source - this creates u-boot.bin]
   # wget ftp://ftp.denx.de/pub/u-boot/u-boot-2011.03.tar.bz2

--- a/docs/arm/realview-eb-mpcore.txt
+++ b/docs/arm/realview-eb-mpcore.txt
@@ -11,7 +11,7 @@ Please follow the steps below to build & run Basic Firmware on
 Realview-EB-MPCore guest with Xvisor running on QEMU Realview-EB-MPCore Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/realview-pb-a8.txt
+++ b/docs/arm/realview-pb-a8.txt
@@ -11,7 +11,7 @@ Please follow the steps below to build & run Basic Firmware on Realview-PB-A8
 guest with Xvisor running on QEMU Realview-PB-A8 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/sun4i-cubieboard-qemu.txt
+++ b/docs/arm/sun4i-cubieboard-qemu.txt
@@ -11,7 +11,7 @@ Please follow the steps below to build & run Basic Firmware on Realview-PB-A8
 guest with Xvisor running on QEMU Cubieboard Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/sun4i-hackberry.txt
+++ b/docs/arm/sun4i-hackberry.txt
@@ -21,7 +21,7 @@ Following are steps to create these images and then boot Xvisor on Allwinner
 A10:
 
   [1. Build environment]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/sun7i-cubieboard2.txt
+++ b/docs/arm/sun7i-cubieboard2.txt
@@ -26,7 +26,7 @@ Following are steps to create these images and then boot Xvisor on Allwinner
 A20:
 
   [1. Build environment]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/versatilepb.txt
+++ b/docs/arm/versatilepb.txt
@@ -10,7 +10,7 @@ Please follow the steps below to build & run Basic Firmware on VersatilePB
 guest with Xvisor running on QEMU VersatilePB Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/vexpress-a15-nove.txt
+++ b/docs/arm/vexpress-a15-nove.txt
@@ -11,7 +11,7 @@ Please follow the steps below to build & run Basic Firmware on Realview-PB-A8
 guest with Xvisor running on QEMU Vexpress-A15 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/vexpress-a15.txt
+++ b/docs/arm/vexpress-a15.txt
@@ -12,7 +12,7 @@ Please follow the steps below to build & run Xvisor on ARM Fast Models
 Vexpress-A15 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/docs/arm/vexpress-a9.txt
+++ b/docs/arm/vexpress-a9.txt
@@ -11,7 +11,7 @@ Please follow the steps below to build & run Basic Firmware on Realview-PB-A8
 guest with Xvisor running on QEMU Vexpress-A9 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/common/busybox/README
+++ b/tests/arm32/common/busybox/README
@@ -43,11 +43,11 @@ Please follow the steps below to build a RAMDISK using BusyBox, to be used as
 RootFS for ARM Linux guest:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-none-linux-gnueabi-
+  # export CROSS_COMPILE=arm-none-linux-gnueabi-
   OR
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
   OR
-  # CROSS_COMPILE=arm-linux-gnueabihf-
+  # export CROSS_COMPILE=arm-linux-gnueabihf-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/realview-eb-mpcore/basic/README
+++ b/tests/arm32/realview-eb-mpcore/basic/README
@@ -15,7 +15,7 @@ Please follow the steps below to build & run Basic Firmware on
 Realview-EB-MPCore Guest with Xvisor running on QEMU Realview-EB-MPCore Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/realview-eb-mpcore/linux/README
+++ b/tests/arm32/realview-eb-mpcore/linux/README
@@ -16,7 +16,7 @@ Follow the steps below to build & run Linux kernel with Busybox RootFS on
 Realview-EB-MPCore Guest with Xvisor running on QEMU Realview-EB-MPCore Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/realview-pb-a8/atomthreads/README
+++ b/tests/arm32/realview-pb-a8/atomthreads/README
@@ -13,7 +13,7 @@ Please follow the steps below to build & run Atomthreads on Realview-PB-A8
 Guest with Xvisor running on QEMU Realview-PB-A8 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/realview-pb-a8/basic/README
+++ b/tests/arm32/realview-pb-a8/basic/README
@@ -15,7 +15,7 @@ Please follow the steps below to build & run Basic firmware on Realview-PB-A8
 Guest with Xvisor running on QEMU Realview-PB-A8 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/realview-pb-a8/linux/README
+++ b/tests/arm32/realview-pb-a8/linux/README
@@ -16,7 +16,7 @@ Follow the steps below to build & run Linux kernel with Busybox RootFS on
 Realview-PB-A8 Guest with Xvisor running on QEMU Realview-PB-A8 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/versatilepb/basic/README
+++ b/tests/arm32/versatilepb/basic/README
@@ -15,7 +15,7 @@ Please follow the steps below to build & run Basic Firmware on VersatilePB
 Guest with Xvisor running on QEMU VersatilePB Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/versatilepb/linux/README
+++ b/tests/arm32/versatilepb/linux/README
@@ -16,7 +16,7 @@ Please follow the steps below to build & run Linux kernel with Busybox
 RootFS on VersatilePB Guest with Xvisor running on QEMU VersatilePB Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/vexpress-a15/basic/README
+++ b/tests/arm32/vexpress-a15/basic/README
@@ -15,7 +15,7 @@ Please follow the steps below to build & run Basic Firmware on VExpress-A15
 Guest with Xvisor running on ARM Fast Model VExpress-A15 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/vexpress-a15/linux/README
+++ b/tests/arm32/vexpress-a15/linux/README
@@ -16,7 +16,7 @@ Please follow the steps below to build & run Linux kernel with Busybox
 RootFS on VExpress-A15 Guest with Xvisor running on ARM Fast Models Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/vexpress-a9/basic/README
+++ b/tests/arm32/vexpress-a9/basic/README
@@ -15,7 +15,7 @@ Please follow the steps below to build & run Basic Firmware on VExpress-A9
 Guest with Xvisor running on QEMU VExpress-A9 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/vexpress-a9/linux/README
+++ b/tests/arm32/vexpress-a9/linux/README
@@ -16,7 +16,7 @@ Follow the steps below to build & run Linux kernel with Busybox RootFS on
 VExpress-A9 Guest with Xvisor running on QEMU VExpress-A9 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/virt-v7/basic/README
+++ b/tests/arm32/virt-v7/basic/README
@@ -14,7 +14,7 @@ Please follow the steps below to build & run Basic Firmware on Virt-v7
 Guest with Xvisor running on ARM Fast Model VExpress-A15 Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>

--- a/tests/arm32/virt-v7/linux/README
+++ b/tests/arm32/virt-v7/linux/README
@@ -16,7 +16,7 @@ RootFS on Virt-v7 (paravirtualized ARMv7) Guest with Xvisor running on
 ARM Fast Models Host:
 
   [1. Build environment for Xvisor]
-  # CROSS_COMPILE=arm-linux-gnueabi-
+  # export CROSS_COMPILE=arm-linux-gnueabi-
 
   [2. GoTo Xvisor source directory]
   # cd <xvisor_source_directory>


### PR DESCRIPTION
I propose to systematically export CROSS_COMPILE value environment variable so that the value of the variable is taken into account for each sub-processes launched during build process (typically during make)