### PR TITLE
fix build with gcc 10

### DIFF
--- a/drivers/mmc/core/core.h
+++ b/drivers/mmc/core/core.h
@@ -64,7 +64,7 @@ int mmc_go_idle(struct mmc_host *host);
  * Note: Must be called with host->lock held.
  */
 extern struct vmm_bus sdio_bus_type;
-struct vmm_device_type sdio_func_type;
+extern struct vmm_device_type sdio_func_type;
 
 int __sdio_attach(struct mmc_host *host);
 

--- a/emulators/display/drawfn.h
+++ b/emulators/display/drawfn.h
@@ -69,14 +69,14 @@ typedef void (*drawfn)(struct vmm_surface *,
 				 DRAWFN_ORDER_MAX * \
 				 DRAWFN_FORMAT_MAX)
 
-drawfn drawfn_surface_fntable_8[DRAWFN_FNTABLE_SIZE];
+extern drawfn drawfn_surface_fntable_8[DRAWFN_FNTABLE_SIZE];
 
-drawfn drawfn_surface_fntable_15[DRAWFN_FNTABLE_SIZE];
+extern drawfn drawfn_surface_fntable_15[DRAWFN_FNTABLE_SIZE];
 
-drawfn drawfn_surface_fntable_16[DRAWFN_FNTABLE_SIZE];
+extern drawfn drawfn_surface_fntable_16[DRAWFN_FNTABLE_SIZE];
 
-drawfn drawfn_surface_fntable_24[DRAWFN_FNTABLE_SIZE];
+extern drawfn drawfn_surface_fntable_24[DRAWFN_FNTABLE_SIZE];
 
-drawfn drawfn_surface_fntable_32[DRAWFN_FNTABLE_SIZE];
+extern drawfn drawfn_surface_fntable_32[DRAWFN_FNTABLE_SIZE];
 
 #endif


### PR DESCRIPTION
Define variables in header files as extern to avoid the following build failure
with gcc 10 (which defaults to -fno-common):

```
/home/giuliobenetti/autobuild/run/instance-3/output-1/host/bin/arm-buildroot-linux-gnueabihf-ld:
/home/giuliobenetti/autobuild/run/instance-3/output-1/build/xvisor-0.3.0/build/drivers/mmc/core/mmc.o:/home/giuliobenetti/autobuild/run/instance-3/output-1/build/xvisor-0.3.0/drivers/mmc/core/core.h:67:
multiple definition of `sdio_func_type';
/home/giuliobenetti/autobuild/run/instance-3/output-1/build/xvisor-0.3.0/build/drivers/mmc/core/core.o:/home/giuliobenetti/autobuild/run/instance-3/output-1/build/xvisor-0.3.0/drivers/mmc/core/core.h:67:
first defined here
```

Fixes:
 - http://autobuild.buildroot.org/results/b6070c0721b33824e71833ce53423979980aa598

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>