### PR TITLE
Fix grep warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ AS		=	$(CC)
 DTC		=	dtc
 
 # Check whether the compiler supports --no-warn-rwx-segments
-CC_SUPPORT_WARN_RWX_SEGMENTS := $(shell $(CC) -nostdlib -Wl,--no-warn-rwx-segments -x c /dev/null -o /dev/null 2>&1 | grep "\-no\-warn\-rwx\-segments" >/dev/null && echo n || echo y)
+CC_SUPPORT_WARN_RWX_SEGMENTS := $(shell $(CC) -nostdlib -Wl,--no-warn-rwx-segments -x c /dev/null -o /dev/null 2>&1 | grep -- "--no-warn-rwx-segments" >/dev/null && echo n || echo y)
 
 # Setup compilation flags
 cppflags=-include $(OPENCONF_TMPDIR)/$(OPENCONF_AUTOHEADER)

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ compile_ld = $(V)mkdir -p `dirname $(1)`; \
 	     $(CC) $(3) $(ldflags) -Wl,-T$(2) -o $(1)
 compile_nm = $(V)mkdir -p `dirname $(1)`; \
 	     echo " (nm)        $(subst $(build_dir)/,,$(1))"; \
-	     $(NM) -n $(2) | grep -v '\( [aNUw] \)\|\(__crc_\)\|\( \$[adt]\)' > $(1)
+	     $(NM) -n $(2) | grep -v '\( [aNUw] \)\|\(__crc_\)\|\( \$$[adt]\)' > $(1)
 compile_objcopy = $(V)mkdir -p `dirname $(1)`; \
 	     echo " (objcopy)   $(subst $(build_dir)/,,$(1))"; \
 	     $(OBJCOPY) -O binary $(2) $(1)


### PR DESCRIPTION
Hi,
This pull request fixes two grep warnings, seen with GNU grep 3.8.
Please see each commit log for the details.
Thanks!