### PR TITLE
RISC-V: Force no-pie code generation and static link

### DIFF
--- a/arch/riscv/cpu/generic/objects.mk
+++ b/arch/riscv/cpu/generic/objects.mk
@@ -67,6 +67,11 @@ cpu-cflags += -fno-strict-aliasing -O2
 cpu-asflags += $(arch-cflags-y) -march=$(march-nonld-isa-y)
 cpu-ldflags += $(arch-ldflags-y) -march=$(march-ld-isa-y)
 
+cpu-cflags += -fno-pie
+cpu-asflags += -fno-pie
+cpu-ldflags += -static
+cpu-mergeflags += -static
+
 cpu-objs-y+= cpu_entry.o
 cpu-objs-y+= cpu_proc.o
 cpu-objs-y+= cpu_tlb.o


### PR DESCRIPTION
Some toolchains are now enabling PIE for security reasons by default. When XVisor is built with such a RISC-V toolchain, it is crashing just after OpenSBI, in early Xvisor startup (before any message is printed on the console).

Hangs looks like those described in:

https://github.com/xvisor/xvisor/issues/144
https://github.com/xvisor/xvisor/issues/159

Forcing -fno-pie code generation and -static link will explicitly disable PIE with those toolchains, hence fixing those issues.

This issue was observed while using a riscv64 gcc toolchain from: https://toolchains.bootlin.com/downloads/releases/toolchains/riscv64-lp64d/tarballs/riscv64-lp64d--glibc--bleeding-edge-2022.08-1.tar.bz2