### PR TITLE
Fix python shebang

### DIFF
--- a/tools/scripts/d2c.py
+++ b/tools/scripts/d2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#! /usr/bin/env python3
 #/**
 # Copyright (c) 2013 Anup Patel.
 # All rights reserved.

--- a/tools/scripts/memimg.py
+++ b/tools/scripts/memimg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#! /usr/bin/env python3
 #/**
 # Copyright (c) 2011 Anup Patel.
 # All rights reserved.


### PR DESCRIPTION
This pull request changes the Python script "shebang" to `#! /usr/bin/env python3` to allow using other interpreters in the PATH, or virtual environment.

It also fixes builds on host not providing the "python" interpreter binary.

See PEP 394 recommendation: https://peps.python.org/pep-0394/