### PR TITLE
[DRIVERS] virtio: fix virtio test bit

### DIFF
--- a/drivers/include/drv/virtio_host.h
+++ b/drivers/include/drv/virtio_host.h
@@ -417,7 +417,7 @@ static inline bool __virtio_host_test_bit(
 	/* Did you forget to fix assumptions on max features? */
 	BUG_ON(fbit >= 64);
 
-	return vdev->features & BIT_ULL(fbit);
+	return !!(vdev->features & BIT_ULL(fbit));
 }
 
 /**


### PR DESCRIPTION
I noticed that modern virtio hosts (version 2) were not working; you can verify this using QEMU, for example:
```
$qemu -M virt --global virtio-mmio.force-legacy=false ...
```

The underlying reason is that `__virtio_host_test_bit` will always return `false` for `fbit >= sizeof(bool)` and will eventually be optimized away by GCC entirely. This patch should bring it in line with what you probably intended.