### PR TITLE
virtio_host_blk: mark device ready before using its virtqueues

### DIFF
--- a/drivers/block/virtio_host_blk.c
+++ b/drivers/block/virtio_host_blk.c
@@ -604,6 +604,12 @@ static int virtio_host_blk_probe(struct virtio_host_device *vdev)
 	}
 	vblk->bdev->rq = vmm_blockrq_to_rq(vblk->brq);
 
+	/* Save VirtIO host block pointer in VirtIO device */
+	vblk->vdev->priv = vblk;
+
+	/* Make VirtIO device ready */
+	virtio_host_device_ready(vblk->vdev);
+
 	/* Register block device instance */
 	rc = vmm_blockdev_register(vblk->bdev);
 	if (rc) {
@@ -611,12 +617,6 @@ static int virtio_host_blk_probe(struct virtio_host_device *vdev)
 			   "failed to register block device\n");
 		goto fail_free_brq;
 	}
-
-	/* Save VirtIO host block pointer in VirtIO device */
-	vblk->vdev->priv = vblk;
-
-	/* Make VirtIO device ready */
-	virtio_host_device_ready(vblk->vdev);
 
 	/* Read serial number */
 	virtio_host_blk_read_serial(vblk);


### PR DESCRIPTION
I noticed that sometimes xvisor starts using a virtio-blk device before it has been marked ready. Here is the callstack I observed:

```
virtio_host_blk_probe
  vmm_blockdev_register 
    blockpart_blk_notification
      blockpart_signal_one_work --> blockpart_thread_main (potentially on different core)
```

My solution was to mark the device ready before adding the blockdevice via `vmm_blockdev_register`, so the block layer is free to submit requests via the virtqueues from `blockpart_thread_main`.