### PR TITLE
irq-riscv-imsic: fix imsic without handlers

### DIFF
--- a/drivers/irqchip/irq-riscv-imsic.c
+++ b/drivers/irqchip/irq-riscv-imsic.c
@@ -1082,6 +1082,12 @@ done:
 		nr_handlers++;
 	}
 
+	if (nr_handlers == 0) {
+		vmm_lerror(node->name, "Found no suitable handler\n");
+		rc = VMM_ENODEV;
+		goto out_ids_cleanup;
+	}
+
 	/* Initialize IPI domain */
 	rc = imsic_ipi_domain_init(priv);
 	if (rc) {


### PR DESCRIPTION
I noticed that when I reverse the order of S-mode and M-mode IMSICs in the devicetree, that xvisor fails to boot when M-mode IMSIC comes first. We have a `for` loop in line 1004 that exits when the IMSIC interrupt is not `IRQ_S_EXT` (line 1023). This happens for the M-mode IMSIC (its irq is `IRQ_M_EXT`), so that `imsic_parent_irq` never gets set.

Later we call `vmm_cpuhp_register`, which leads to `imsic_starting_cpu` getting called, which fails because `imsic_parent_irq` is not set.

When I reverse the order back (first S-mode, then M-mode), the M-mode IMSIC gets filtered out during `imsic_init` via `imsic_init_done`.