### PR TITLE
irq-riscv-aclint: fix overlapping irqdomains

### DIFF
--- a/drivers/irqchip/irq-riscv-aclint-swi.c
+++ b/drivers/irqchip/irq-riscv-aclint-swi.c
@@ -147,7 +147,7 @@ static int __init aclint_swi_init(struct vmm_devtree_node *node)
 	}
 
 	/* Register ACLINT_SWI domain */
-	aclint_swi_domain = vmm_host_irqdomain_add(NULL, BITS_PER_LONG * 2, 1,
+	aclint_swi_domain = vmm_host_irqdomain_add(NULL, BITS_PER_LONG * 3, 1,
 						   &irqdomain_simple_ops,
 						   NULL);
 	if (!aclint_swi_domain) {


### PR DESCRIPTION
I have noticed that when I run a simulation with both IMSIC and ACLINT present in a system, xvisor registers overlapping irqdomains:

```
irq-riscv-aclint-swi.c:150 -> add irqdomain for aclint_sw using base=128 size=1 (i.e. 2 * XLEN)
irq-riscv-imsic.c:522 -> add irqdomain for imsic_ipi using base=128 size=1 (i.e. 2 * XLEN)
```

I arbitrarily chose `3 * XLEN` for the ACLINT to move it out of the way and prevent an error later when IMSIC tries to register an already existing irqdomain. I am not sure how those numbers were chosen (maybe `2 * XLEN + 1` would also have been a valid option?)

