### PR TITLE
Makefile: Use '-std=gnu11' to fix build with GCC 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ cppflags+=-I$(libs_dir)/include
 cppflags+=$(cpu-cppflags)
 cppflags+=$(board-cppflags)
 cppflags+=$(libs-cppflags-y)
-cflags=-g -Wall -nostdlib --sysroot=$(drivers_dir)/include -fno-builtin -fno-stack-protector -D__VMM__
+cflags=-std=gnu11 -g -Wall -nostdlib --sysroot=$(drivers_dir)/include -fno-builtin -fno-stack-protector -D__VMM__
 cflags+=$(board-cflags)
 cflags+=$(cpu-cflags)
 cflags+=$(libs-cflags-y)


### PR DESCRIPTION
GCC 15 changed the default C standard version to C23 [1], resulting in errors from the xvisor definitions of bool from core/include/vmm_types.h, which is a reserved keyword under C23.

Since CFLAGS are hardcoded in the main Makefile, add '-std=gnu11' to 'cflags' to resolve the error.

[1] https://gcc.gnu.org/gcc-15/porting_to.html

Fixes:
https://gitlab.com/buildroot.org/buildroot/-/jobs/11042295047