### PR TITLE
Update vcpu after scheduler switch to process the correct IRQs in vmm_scheduler_irq_exit()

### DIFF
--- a/core/vmm_scheduler.c
+++ b/core/vmm_scheduler.c
@@ -856,6 +856,9 @@ void vmm_scheduler_irq_exit(arch_regs_t *regs)
 	if ((vmm_manager_vcpu_get_state(vcpu) != VMM_VCPU_STATE_RUNNING) ||
 	    schedp->yield_on_irq_exit) {
 		vmm_scheduler_switch(schedp, schedp->irq_regs);
+		
+		/* vcpu has switched! */
+		vcpu = schedp->current_vcpu;
 		schedp->yield_on_irq_exit = FALSE;
 	}
 


### PR DESCRIPTION
**System Configuration**

- The host system (on top of which Xvisor runs) is a single, gem5-simulated rv64imafdch core.
- Xvisor is configured (SMP on) to provide 2 VCPUs.
- A single guest is hosted, running Linux 6.7 (SMP on) which "sees" and utilizes both VCPUs.


**Bug Setup & Manifestation**

-  A small workload is being executed on the Linux guest. The guest (seeing 2 CPUs) has scheduled a kernel thread on one and the workload on the other.

-   The two relevant threads of the guest are being scheduled on the two VCPUs which in turn must be multiplexed across time by Xvisor on the single host CPU (simulated by gem5).

-  Linux has programmed a timer for both VCPUs. Xvisor keeps all the timers in a sorted list, only scheduling the earliest deadline on the single underlying host CPU.

-  At a certain point in time, while the kernel thread of the guest is being executed on the CPU, the machine timer interrupt fires. The interrupt is eventually forwarded to HS-mode (Xvisor) for handling.

- Xvisor examines the global timer list for the single host CPU. The list in general contains deadlines requested by some VCPU or scheduling deadlines requested by Xvisor's scheduler. The list is examined in a while loop, handling any expired events.

- In our case, both VCPUs have programmed timers as mentioned, and it so happens that they both have expired.
- The corresponding interrupts are not immediately injected. Xvisor marks that these VCPUs have pending interrupts via its IRQ module.
- When interrupt handling is over, the Xvisor scheduler decides to continue with the VCPU running the kernel thread.

- Its interrupt is injected and observed normally by the kernel code.

- This kernel thread continues executing several instructions, until, at some point, it decides to go to sleep, essentially yielding the VCPU it is running on.

- The Xvisor scheduler finds that the other VCPU (the one running the workload thread) is in the ready state, and decides to schedule it to run.

- The specific code path exercised at this point causes a bug. The workload thread's VCPU should have a pending IRQ which should be injected as soon as it is scheduled. However, Xvisor swaps the VCPUs in such a way that the IRQs of that VCPU are never processed and injected. The interrupt thus is never injected on the workload thread even though the deadline has long passed.


The code in question is the following:

```C
void vmm_scheduler_irq_exit(arch_regs_t *regs)
{
    struct vmm_scheduler_ctrl *schedp = &this_cpu(sched);
    struct vmm_vcpu *vcpu = NULL;

    /* Determine current vcpu */
    vcpu = schedp->current_vcpu;
    if (!vcpu) {
        return;
    }

    /* If current vcpu is not RUNNING or yield on exit is set
     * then context switch
     */
    if ((vmm_manager_vcpu_get_state(vcpu) != VMM_VCPU_STATE_RUNNING) ||
        schedp->yield_on_irq_exit) {
        vmm_scheduler_switch(schedp, schedp->irq_regs);
        schedp->yield_on_irq_exit = FALSE;
    }

    /* VCPU irq processing */
    vmm_vcpu_irq_process(vcpu, regs);

    /* Indicate that we have exited IRQ */
    if (schedp->irq_context) {
        schedp->irq_process_ns +=
            vmm_timer_timestamp() - schedp->irq_enter_tstamp;
    } else {
        schedp->exp_process_ns +=
            vmm_timer_timestamp() - schedp->irq_enter_tstamp;
    }
    schedp->irq_context = FALSE;

    /* Clear pointer to IRQ registers */
    schedp->irq_regs = NULL;
}
```


If the current VCPU yields, we get a call to vmm_scheduler_switch(schedp, schedp->irq_regs); which will swap the current vcpu.
   

This line however: vmm_vcpu_irq_process(vcpu, regs); **will operate on the previous vcpu!!!** (saved on the call frame)
This causes the pending IRQs to be missed entirely. We fix this by updating the current VCPU via schedp after scheduler switch.
