### PR TITLE
TESTS: add -fno-pic compiler flag

### DIFF
--- a/tests/common/basic/Makefile.inc
+++ b/tests/common/basic/Makefile.inc
@@ -23,9 +23,9 @@
 
 FW_CROSS_COMPILE=$(CROSS_COMPILE)
 FW_CPPFLAGS=$(ARCH_CPPFLAGS) -I. -I$(ARCH_BASIC_DIR) -I$(ARCH_DIR)
-FW_CFLAGS=$(ARCH_CFLAGS) $(FW_CPPFLAGS) -g -Wall -Werror -nostdlib -std=gnu11
-FW_ASFLAGS=$(ARCH_ASFLAGS) $(FW_CPPFLAGS) -g -Wall -Werror -nostdlib -D__ASSEMBLY__
-FW_LDFLAGS=$(ARCH_LDFLAGS) $(FW_CFLAGS) -Wl,--build-id=none -Wl,-T$(ARCH_LDSCRIPT)
+FW_CFLAGS=$(ARCH_CFLAGS) $(FW_CPPFLAGS) -fno-pic -g -Wall -Werror -nostdlib -std=gnu11
+FW_ASFLAGS=$(ARCH_ASFLAGS) $(FW_CPPFLAGS) -fno-pic -g -Wall -Werror -nostdlib -D__ASSEMBLY__
+FW_LDFLAGS=$(ARCH_LDFLAGS) $(FW_CFLAGS) -Wl,--no-pie -Wl,--build-id=none -Wl,-T$(ARCH_LDSCRIPT)
 
 ifdef CROSS_COMPILE
 CC		=	$(CROSS_COMPILE)gcc


### PR DESCRIPTION
Should fix #175 and #179.

I compiled `build/tests/riscv/virt64/basic/firmware.bin` on my Arch Linux system:

```sh
export CROSS_COMPILE='riscv64-linux-gnu-'
export ARCH='riscv'
make O=./build generic-64b-defconfig
make -j16
make -j16 -C tests/riscv/virt64/basic
```

And the generated firmware becomes position-independent code:
```sh
llvm-objdump -D --mattr=+c build/tests/riscv/virt64/basic/firmware.elf -z | head -n 20

build/tests/riscv/virt64/basic/firmware.elf:    file format elf64-littleriscv

Disassembly of section .text:

0000000080000000 <_start>:
80000000: 0aa04c63      bgtz    a0, 0x800000b8 <_secondary_wait>
80000004: 00016717      auipc   a4, 0x16
80000008: 1ec73703      ld      a4, 0x1ec(a4)
8000000c: 6318          ld      a4, 0x0(a4)
8000000e: 00016797      auipc   a5, 0x16
80000012: 1ea7b783      ld      a5, 0x1ea(a5)
80000016: 02f70463      beq     a4, a5, 0x8000003e <_skip_relocate>
8000001a: 00016817      auipc   a6, 0x16
8000001e: 22e83803      ld      a6, 0x22e(a6)

0000000080000022 <_relocate>:
80000022: 0007b883      ld      a7, 0x0(a5)
80000026: 01173023      sd      a7, 0x0(a4)
8000002a: 0721          addi    a4, a4, 0x8
```

In the assembly above, `la a4, exec_start` in `arch_entry.S` is compiled to `auipc a4, 0x16` + `ld a4, 0x1ec(a4)`. This is looking up a GOT entry which was never initialized, causing invalid memory accesses in later relocation.

Adding `-fno-pic` compiler flag and `-Wl,--no-pie` linker flag fixes it.