### PR TITLE
[RISC-V] Disable MMU before page table cleanup

### DIFF
--- a/arch/riscv/cpu/generic/cpu_mmu_initial_pgtbl.c
+++ b/arch/riscv/cpu/generic/cpu_mmu_initial_pgtbl.c
@@ -319,12 +319,12 @@ void __attribute__ ((section(".entry")))
 	}
 
 skip_sv48_test:
-	/* Cleanup and disable MMU */
+	/* Disable MMU and cleanup */
+	csr_write(CSR_SATP, 0);
+	__sfence_vma_all();
 	for (i = 0; i < PGTBL_ROOT_ENTCNT; i++) {
 		pgtbl[i] = 0x0ULL;
 	}
-	csr_write(CSR_SATP, 0);
-	__sfence_vma_all();
 #endif
 }
 


### PR DESCRIPTION
The cleanup loop at skip_sv48_test in __detect_pgtbl_mode() zeroes pgtbl[] while the MMU is still enabled. pgtbl[0] is the root PTE at index 0 (load_start is 0x80200000, VPN[4]=0) which maps the entire address space via a sv57 gigapage.
    
The first store in the cleanup loop zeroes pgtbl[0]. The very next store to pgtbl[1] requires a page table walk which reads pgtbl[0] from memory, finds 0x0 (invalid PTE), and faults.
    
Any implementation that performs a page table walk on every memory access will fault deterministically on the second iteration. Implementations with a warm TLB may mask the bug by hitting a cached entry and never re-walking, but this is not guaranteed.
    
Fix by disabling satp and flushing the TLB before the cleanup loop, ensuring all subsequent accesses bypass the MMU entirely and use physical addresses directly.